### PR TITLE
Sanitize display name

### DIFF
--- a/lib/src/name_addr_header.dart
+++ b/lib/src/name_addr_header.dart
@@ -2,12 +2,12 @@ import 'grammar.dart';
 import 'uri.dart';
 import 'utils.dart';
 
-// derived from https://www.rfc-editor.org/rfc/rfc3261.html#section-25
-final RegExp illegalDisplayNameCharacters = RegExp(r'\x0A|\x0D'); // LF, CR
+// derived from https://www.rfc-editor.org/rfc/rfc3261.html#section-25 (dfferent from spec: DEL as illegal)
+final RegExp illegalDisplayNameCharacters = RegExp(r'\x0A|\x0D|\x7F'); // LF, CR, DEL
 final String illegalReplacement = '';
-// need to escape ASCII (0x00-0x7F) except for LF 0x0A, CR 0x0D, SPACE 0x20, ! 0x21, and 'regular' chars (0x23-5B,5D-7E)
+// need to escape ASCII (0x00-0x7F) except for LF 0x0A, CR 0x0D, SPACE 0x20, ! 0x21, 'regular' chars (0x23-5B,5D-7E), and DEL 0x7F
 final RegExp needEscapingDisplayNameChars =
-    RegExp(r'[\x00-\x09]|\x0B|\x0C|[\x0E-\x1F]|\x22|\x5C|\x7F');
+    RegExp(r'[\x00-\x09]|\x0B|\x0C|[\x0E-\x1F]|\x22|\x5C');
 
 class NameAddrHeader {
   NameAddrHeader(URI? uri, String? display_name,

--- a/lib/src/name_addr_header.dart
+++ b/lib/src/name_addr_header.dart
@@ -2,7 +2,7 @@ import 'grammar.dart';
 import 'uri.dart';
 import 'utils.dart';
 
-// derived from https://www.rfc-editor.org/rfc/rfc3261.html#section-25 (dfferent from spec: DEL as illegal)
+// derived from https://www.rfc-editor.org/rfc/rfc3261.html#section-25 (*different from RFC: DEL as illegal)
 final RegExp illegalDisplayNameCharacters = RegExp(r'\x0A|\x0D|\x7F'); // LF, CR, DEL
 final String illegalReplacement = '';
 // need to escape ASCII (0x00-0x7F) except for LF 0x0A, CR 0x0D, SPACE 0x20, ! 0x21, 'regular' chars (0x23-5B,5D-7E), and DEL 0x7F


### PR DESCRIPTION
sip_as was sanitizing just DOUBLEQUOTE and BACKSLASH. this is more comprehensive.
This replaces illegal characters (\r or \n) with empty string. Should I stick with that or replace with some special delimiter?